### PR TITLE
feat : 기본적인 채팅 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/betgether/betgether_server/domain/chat/config/WebSocketConfig.java
+++ b/src/main/java/com/betgether/betgether_server/domain/chat/config/WebSocketConfig.java
@@ -1,0 +1,27 @@
+package com.betgether.betgether_server.domain.chat.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+    // 엔드포인트 등록을 위한 설정
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        //@TODO:향후 도메인 생기면 추가
+        registry.addEndpoint("/ws")
+                .setAllowedOriginPatterns("*")
+                .withSockJS();
+    }
+
+    // prefix로 sub이 붙으면 구독, pub이 붙으면 메시지 송신
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/sub");
+        registry.setApplicationDestinationPrefixes("/pub");
+    }
+}

--- a/src/main/java/com/betgether/betgether_server/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/betgether/betgether_server/domain/chat/controller/ChatController.java
@@ -1,0 +1,23 @@
+package com.betgether.betgether_server.domain.chat.controller;
+
+import com.betgether.betgether_server.domain.chat.dto.request.ChatSendRequest;
+import com.betgether.betgether_server.domain.chat.dto.response.ChatSendResponse;
+import com.betgether.betgether_server.domain.chat.service.ChatService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@RequiredArgsConstructor
+public class ChatController {
+
+    private final SimpMessagingTemplate messagingTemplate;
+    private final ChatService chatService; // DB 저장을 담당하는 서비스
+
+    @MessageMapping("/chat/message") // 유저가 /pub/chat/message로 전송
+    public void messageFromUser(ChatSendRequest message) {
+        // 3. 서버는 채팅을 데이터베이스에 저장한다
+        chatService.broadcastMessage(message);
+    }
+}

--- a/src/main/java/com/betgether/betgether_server/domain/chat/dto/request/ChatSendRequest.java
+++ b/src/main/java/com/betgether/betgether_server/domain/chat/dto/request/ChatSendRequest.java
@@ -2,6 +2,8 @@ package com.betgether.betgether_server.domain.chat.dto.request;
 
 public record ChatSendRequest(
         String content,
-        String type
+        String type,
+        Integer getherId,
+        Integer userId
 ) {
 }

--- a/src/main/java/com/betgether/betgether_server/domain/chat/handler/WebSocketEventListener.java
+++ b/src/main/java/com/betgether/betgether_server/domain/chat/handler/WebSocketEventListener.java
@@ -1,0 +1,22 @@
+package com.betgether.betgether_server.domain.chat.handler;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionConnectEvent;
+
+@Component
+public class WebSocketEventListener {
+
+    //private final UserService userService;
+
+    @EventListener
+    public void handleWebSocketConnectListener(SessionConnectEvent event) {
+        StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
+        String userId = (String) headerAccessor.getSessionAttributes().get("userId");
+
+        // 여기서 직접 DB를 건드리지 않고 Service를 호출하는 것이 좋습니다.
+        //userService.userConnect(userId);
+        System.out.println("유저 연결 처리 완료");
+    }
+}

--- a/src/main/java/com/betgether/betgether_server/domain/chat/service/ChatService.java
+++ b/src/main/java/com/betgether/betgether_server/domain/chat/service/ChatService.java
@@ -1,0 +1,22 @@
+package com.betgether.betgether_server.domain.chat.service;
+
+import com.betgether.betgether_server.domain.chat.dto.request.ChatSendRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+@Service // Bean 등록을 위해 추가
+@RequiredArgsConstructor // final이 붙은 필드로 생성자를 자동 생성
+public class ChatService {
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    public void broadcastMessage(ChatSendRequest message) {
+        // 4. 유저가 속한 방(/sub/chat/room/{roomId})으로 브로드캐스트
+        // 이 주소를 구독하고 있는 모든 유저에게 메시지가 전달됩니다.
+        messagingTemplate.convertAndSend("/sub/chat/gether/" + message.getherId(), message);
+        System.out.println("BROADCAST CHAT : " + message);
+
+        //@TODO: 데이터베이스 저장 로직 구현
+    }
+}


### PR DESCRIPTION
# PR Summary: STOMP 채팅 기능 구현

## 브랜치
- **작업 브랜치**: `4-stomp-chat`
- **베이스 브랜치**: `main`

## 개요
WebSocket과 STOMP 프로토콜을 활용한 실시간 채팅 기능을 구현했습니다. 이 PR에서는 채팅 메시지 송수신을 위한 기본 인프라와 핵심 로직을 구현했습니다.

## 주요 변경사항

### 1. 의존성 추가
**파일**: `build.gradle`
- Spring Boot WebSocket 의존성 추가
  ```gradle
  implementation 'org.springframework.boot:spring-boot-starter-websocket'
  ```

### 2. WebSocket 설정
**파일**: `src/main/java/com/betgether/betgether_server/domain/chat/config/WebSocketConfig.java` (신규)
- STOMP 엔드포인트 설정
  - WebSocket 엔드포인트: `/ws`
  - SockJS fallback 지원
  - CORS 설정: 모든 origin 허용 (향후 도메인 생성 시 변경 예정)
- Message Broker 설정
  - 구독(subscribe) prefix: `/sub`
  - 발행(publish) prefix: `/pub`

### 3. 채팅 컨트롤러
**파일**: `src/main/java/com/betgether/betgether_server/domain/chat/controller/ChatController.java` (신규)
- `@MessageMapping("/chat/message")` 엔드포인트 구현
  - 클라이언트가 `/pub/chat/message`로 메시지 전송
  - 수신한 메시지를 ChatService로 전달하여 브로드캐스트 처리

### 4. 채팅 서비스
**파일**: `src/main/java/com/betgether/betgether_server/domain/chat/service/ChatService.java` (신규)
- `broadcastMessage()` 메서드 구현
  - 수신한 메시지를 해당 게더룸(`/sub/chat/gether/{getherId}`)의 모든 구독자에게 브로드캐스트
  - 콘솔 로깅으로 메시지 전송 확인
  - TODO: 데이터베이스 저장 로직 구현 예정

### 5. WebSocket 이벤트 리스너
**파일**: `src/main/java/com/betgether/betgether_server/domain/chat/handler/WebSocketEventListener.java` (신규)
- WebSocket 연결 이벤트 핸들러 구현
  - `SessionConnectEvent` 리스닝
  - 유저 ID 추출 및 연결 처리
  - TODO: UserService와 연동하여 실제 유저 연결 상태 관리 예정

### 6. DTO 업데이트
**파일**: `src/main/java/com/betgether/betgether_server/domain/chat/dto/request/ChatSendRequest.java`
- 필드 추가:
  - `getherId`: 메시지가 전송될 게더룸 식별자
  - `userId`: 메시지 발신자 식별자

### 7. 애플리케이션 설정 변경
**파일**: `src/main/java/com/betgether/betgether_server/BetgetherServerApplication.java`
- 데이터베이스 Auto-configuration 임시 비활성화
  - `DataSourceAutoConfiguration` 제외
  - `DataSourceTransactionManagerAutoConfiguration` 제외
  - `HibernateJpaAutoConfiguration` 제외
  - `@EnableJpaAuditing` 주석 처리
  - *이유*: 채팅 기능 테스트를 위해 DB 연결 없이 실행 가능하도록 설정

## 구현된 채팅 플로우

1. **연결**: 클라이언트가 `/ws` 엔드포인트로 WebSocket 연결
2. **구독**: 클라이언트가 특정 게더룸 `/sub/chat/gether/{getherId}` 구독
3. **메시지 전송**: 클라이언트가 `/pub/chat/message`로 메시지 전송
4. **브로드캐스트**: 서버가 해당 게더룸을 구독 중인 모든 클라이언트에게 메시지 브로드캐스트

## 테스트 방법

1. 서버 실행 후 WebSocket 클라이언트로 `/ws` 엔드포인트에 연결
2. `/sub/chat/gether/{getherId}` 토픽 구독
3. `/pub/chat/message`로 다음 형식의 메시지 전송:
   ```json
   {
     "content": "메시지 내용",
     "type": "메시지 타입",
     "getherId": 1,
     "userId": 1
   }
   ```
4. 같은 getherId를 구독 중인 모든 클라이언트가 메시지를 수신하는지 확인

---

🤖 Generated with Claude Code
